### PR TITLE
Add coverage badge

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -30,6 +30,9 @@ jobs:
           pip install .
           python3 -c "import electricpy; print('electricpy.__file__')"
           sphinx-build -M html docsource docs
+      - name: Generate Coverage Badge
+        if: success()
+        run: coverage-badge -o docs/html/coverage.svg
 
       # https://github.com/marketplace/actions/github-pages
       #- if: success()

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -32,7 +32,10 @@ jobs:
           sphinx-build -M html docsource docs
       - name: Generate Coverage Badge
         if: success()
-        run: coverage-badge -o docs/html/coverage.svg
+        run: |
+          pip install -r test/pytestrequires.txt
+          coverage run -m pytest
+          coverage-badge -o docs/html/coverage.svg
 
       # https://github.com/marketplace/actions/github-pages
       #- if: success()

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![Tox Import Test](https://github.com/engineerjoe440/ElectricPy/workflows/Tox%20Tests/badge.svg)
 [![pytest](https://github.com/engineerjoe440/ElectricPy/actions/workflows/pytest.yml/badge.svg?branch=master)](https://github.com/engineerjoe440/ElectricPy/actions/workflows/pytest.yml)
 [![pydocstyle](https://github.com/engineerjoe440/ElectricPy/actions/workflows/pydocstyle.yml/badge.svg?branch=master)](https://github.com/engineerjoe440/ElectricPy/actions/workflows/pydocstyle.yml)
+![Coverage](https://raw.githubusercontent.com/engineerjoe440/ElectricPy/gh-pages/coverage.svg)
 
 [![](https://img.shields.io/pypi/v/electricpy.svg?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/electricpy/)
 [![](https://pepy.tech/badge/electricpy)](https://pepy.tech/project/electricpy)

--- a/docsource/sphinxrequires.txt
+++ b/docsource/sphinxrequires.txt
@@ -4,6 +4,7 @@ numpydoc
 m2r2
 sphinx-sitemap
 sphinx-git
+coverage-badge
 numpy
 matplotlib
 scipy


### PR DESCRIPTION
# Add Coverage Badge to README

This PR uses the Sphinx generation process to evaluate coverage, then push a coverage badge to the `gh-pages` branch to be accessed by the README document.

#### Closes #38