### PR TITLE
Parallel Plate Capacitor and Solenoid Inductance

### DIFF
--- a/electricpy/__init__.py
+++ b/electricpy/__init__.py
@@ -4800,6 +4800,7 @@ def parallel_plate_capacitance(A=None, d=None, e=e0, C=None):
         Distance between the plates, unitless.
     e:  [float]
         Permitivity of the dielectric, unitless.
+        Default value is the permittivity of free space: 8.854E-12
     C:  [float]
         Capacitance, unitless.
     Returns
@@ -4845,6 +4846,7 @@ def solenoid_inductance(A=None, l=None, N=None, u=u0, L=None):
         Number of turns, unitless.
     u:  [float]
         Core permeability, unitless.
+        Default value is the permeability of free space: 4πE-7
     L:  [float]
         Inductance, unitless.
 

--- a/electricpy/__init__.py
+++ b/electricpy/__init__.py
@@ -4790,29 +4790,29 @@ def parallel_plate_capacitance(A=None, d=None, e=e0, C=None):
     Enter three values to calculate the remaing one. Even though every variable
     is unitless, please use the International System of Units.
 
-    .. math:: C =\frac{\varepsilon A}{d}
+    .. math:: C = \frac{\varepsilon \cdot A}{d}
 
     Parameters
     ----------
-    A:  [float]
+    A:  float, optional
         Area of the plate, unitless.
-    d:  [float]
+    d:  float, optional
         Distance between the plates, unitless.
-    e:  [float]
+    e:  float, optional
         Permitivity of the dielectric, unitless.
         Default value is the permittivity of free space: 8.854E-12
-    C:  [float]
+    C:  float, optional
         Capacitance, unitless.
     Returns
     -------
-    A:  [float]
+    A:  float, optional
         Area of the plate, unitless.
-    d:  [float]
+    d:  float, optional
         Distance between the plates, unitless.
-    e:  [float]
+    e:  float, optional
         Permitivity of the dielectric, unitless.
         Default value is the permittivity of free space: 8.854E-12
-    C:  [float]
+    C:  float, optional
         Capacitance, unitless.
     """
     if C == A == d == None:
@@ -4834,34 +4834,34 @@ def solenoid_inductance(A=None, l=None, N=None, u=u0, L=None):
     Enter four values to calculate the remaing one. Even though every variable
     is unitless, please use the International System of Units.
 
-    .. math:: L = \frac{\mu N^2 A}{l}
+    .. math:: L = \frac{\mu \cdot N^2 \cdot A}{l}
 
     Parameters
     ----------
-    A:  [float]
+    A:  float, optional
         Cross sectional area, unitless.
-    l:  [float]
+    l:  float, optional
         Length, unitless.
-    N:  [float]
+    N:  float, optional
         Number of turns, unitless.
-    u:  [float]
+    u:  float, optional
         Core permeability, unitless.
         Default value is the permeability of free space: 4πE-7
-    L:  [float]
+    L:  float, optional
         Inductance, unitless.
 
     Returns
     -------
-    A:  [float]
+    A:  float, optional
         Cross sectional area, unitless.
-    l:  [float]
+    l:  float, optional
         Length, unitless.
-    N:  [float]
+    N:  float, optional
         Number of turns, unitless.
-    u:  [float]
+    u:  float, optional
         Core permeability, unitless.
         Default value is the permeability of free space: 4πE-7
-    L:  [float]
+    L:  float, optional
         Inductance, unitless.
     """
     if L == A == l == N == None:

--- a/electricpy/__init__.py
+++ b/electricpy/__init__.py
@@ -4803,6 +4803,7 @@ def parallel_plate_capacitance(A=None, d=None, e=e0, C=None):
         Default value is the permittivity of free space: 8.854E-12
     C:  float, optional
         Capacitance, unitless.
+
     Returns
     -------
     A:  float, optional

--- a/electricpy/__init__.py
+++ b/electricpy/__init__.py
@@ -4782,6 +4782,100 @@ def wireresistance(length=None,diameter=None,rho=16.8*10**-9,R=None):
     elif R != None and length != None:
         A = rho*length/R
         return _np.sqrt(4*A/pi)
+
+def parallel_plate_capacitance(A=None, d=None, e=e0, C=None):
+    r"""
+    Parallel-Plate Capacitance Calculator.
+
+    Enter three values to calculate the remaing one. Even though every variable
+    is unitless, please use the International System of Units.
+
+    .. math:: C =\frac{\varepsilon A}{d}
+
+    Parameters
+    ----------
+    A:  [float]
+        Area of the plate, unitless.
+    d:  [float]
+        Distance between the plates, unitless.
+    e:  [float]
+        Permitivity of the dielectric, unitless.
+    C:  [float]
+        Capacitance, unitless.
+    Returns
+    -------
+    A:  [float]
+        Area of the plate, unitless.
+    d:  [float]
+        Distance between the plates, unitless.
+    e:  [float]
+        Permitivity of the dielectric, unitless.
+        Default value is the permittivity of free space: 8.854E-12
+    C:  [float]
+        Capacitance, unitless.
+    """
+    if C == A == d == None:
+        raise ValueError("To few arguments.")
+    # Given area and distance
+    if A != None and d != None:
+        return e*A/d
+    # Given capacitance and distance
+    elif C != None and d != None:
+        return d*C/e
+    # Given capacitance and area
+    elif C != None and A != None:
+        return e*A/C
+
+def solenoid_inductance(A=None, l=None, N=None, u=u0, L=None):
+    r"""
+    Solenoid Inductance Calculator.
+
+    Enter four values to calculate the remaing one. Even though every variable
+    is unitless, please use the International System of Units.
+
+    .. math:: L = \frac{\mu N^2 A}{l}
+
+    Parameters
+    ----------
+    A:  [float]
+        Cross sectional area, unitless.
+    l:  [float]
+        Length, unitless.
+    N:  [float]
+        Number of turns, unitless.
+    u:  [float]
+        Core permeability, unitless.
+    L:  [float]
+        Inductance, unitless.
+
+    Returns
+    -------
+    A:  [float]
+        Cross sectional area, unitless.
+    l:  [float]
+        Length, unitless.
+    N:  [float]
+        Number of turns, unitless.
+    u:  [float]
+        Core permeability, unitless.
+        Default value is the permeability of free space: 4πE-7
+    L:  [float]
+        Inductance, unitless.
+    """
+    if L == A == l == N == None:
+        raise ValueError("To few arguments.")
+    # Given area, length and number of turns
+    if A != None and l != None and N != None:
+        return N**2*u*A/l
+    # Given inductance, length and number of turns
+    elif L != None and l != None and N != None:
+        return L*l/(N**2*u)
+    # Given inductance, area and number of turns
+    elif L != None and A != None and N != None:
+        return N**2*u*A/L
+    # Given inductance, area and length
+    elif L != None and A != None and l != None:
+        return _np.sqrt(L*l/(u*A))
         
 def ic_555_astable(R=None,C=None,freq=None,t_high=None,t_low=None):
     """

--- a/test/test_electricpy.py
+++ b/test/test_electricpy.py
@@ -1,4 +1,3 @@
-from unicodedata import decimal
 import pytest
 import numpy as np
 import cmath

--- a/test/test_electricpy.py
+++ b/test/test_electricpy.py
@@ -1,3 +1,4 @@
+from unicodedata import decimal
 import pytest
 import numpy as np
 import cmath
@@ -430,6 +431,73 @@ def test_vectarray():
 
     for i in range(2):
         exec('test_{}()'.format(i))
+
+def test_parallel_plate_capacitance():
+    from electricpy import parallel_plate_capacitance
+
+    # Test 1: In the free space (by default e=e0=8.8542E-12)
+
+    A1 = 100e-4
+    d1 = 8.8542e-2
+    C1 = 1e-12
+
+    # Test capacitance given area and distance
+    assert_almost_equal(parallel_plate_capacitance(A=A1, d=d1), C1)
+    # Test area given capacitance and distance
+    assert_almost_equal(parallel_plate_capacitance(C=C1, d=d1), A1)
+    # Test distance given capacitance and area
+    assert_almost_equal(parallel_plate_capacitance(C=C1, A=A1), d1)
+
+    # Test 2: Not in the free space (e≠8.8542E-12)
+
+    A2 = 100e-4
+    d2 = 8.8542e-2
+    e2 = 17.7084e-12
+    C2 = 2e-12
+
+    # Test capacitance given area, distance and permitivity
+    assert_almost_equal(parallel_plate_capacitance(A=A2, d=d2, e=e2), C2)
+    # Test area given capacitance, distance and permitivity
+    assert_almost_equal(parallel_plate_capacitance(C=C2, d=d2, e=e2), A2)
+    # Test distance given capacitance, area and permitivity
+    assert_almost_equal(parallel_plate_capacitance(C=C2, A=A2, e=e2), d2)
+
+def test_solenoid_inductance():
+    from electricpy import solenoid_inductance
+
+    # Test 1: In the free space (by default u=u0=4πE-7)
+
+    A1 = 2e-3
+    N1 = 550
+    l1 = 20e-2*np.pi
+    L1 = 1.21e-3
+
+    # Test inductance given area, number of turns and length
+    assert_almost_equal(solenoid_inductance(A=A1, N=N1, l=l1), L1)
+    # Test area given inductance, number of turns and length
+    assert_almost_equal(solenoid_inductance(L=L1, N=N1, l=l1), A1)
+    # Test number of turns given inductance, area and length
+    assert_almost_equal(solenoid_inductance(L=L1, A=A1, l=l1), N1)
+    # Test length given inductance, area and number of turns
+    assert_almost_equal(solenoid_inductance(L=L1, A=A1, N=N1), l1)
+
+    # Test 2: Not the free space (u≠4πE-7)
+
+    A2 = 2e-3
+    N2 = 550
+    l2 = 20e-2*np.pi
+    u2 = 100*4e-7*np.pi # Iron permeability
+    L2 = 0.121
+
+    # Test inductance given area, number of turns, length and permeability
+    assert_almost_equal(solenoid_inductance(A=A2, N=N2, l=l2, u=u2), L2)
+    # Test area given inductance, number of turns, length and permeability
+    assert_almost_equal(solenoid_inductance(L=L2, N=N2, l=l2, u=u2), A2)
+    # Test number of turns given inductance, area, length and permeability
+    assert_almost_equal(solenoid_inductance(L=L2, A=A2, l=l2, u=u2), N2)
+    # Test length given inductance, area, number of turns and permeability
+    assert_almost_equal(solenoid_inductance(L=L2, A=A2, N=N2, u=u2), l2)
+
 class Test_air_core_inductor:
 
     def invoke(test_case):


### PR DESCRIPTION
Since previous versions, there is a function to calculate the **resistance of a wire** (`wireresistance`). As a complement, the functions for calculating the **capacitance of a parallel plate capacitor** (`parallel_plate_capacitance`) and the **inductance of a solenoid** (`solenoid_inductance`) have been added.