### PR TITLE
Correct NumPy/SciPy/SymPy Casing in Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ consistency wherever possible, a few of these things to keep in mind include:
 
 **Documentation:** *(a must!)*
 * Format function docstrings according to
-[NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html) standards
+[NumPyDoc](https://numpydoc.readthedocs.io/en/latest/format.html) standards
 * Use the very first line of docstrings to give a brief (one-line) description
 of what the function is used for
 * Whenever possible, use LaTeX `.. math::` blocks to help document the formula(s)

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Check out our full documentation: https://engineerjoe440.github.io/ElectricPy/
 
 ### Dependencies:
 
-- [numpy](https://numpy.org/)
+- [NumPy](https://numpy.org/)
 - [matplotlib](https://matplotlib.org/)
-- [scipy](https://scipy.org/)
-- [sympy](https://www.sympy.org/en/index.html)
+- [SciPy](https://scipy.org/)
+- [SymPy](https://www.sympy.org/en/index.html)
 - [numdifftools](https://numdifftools.readthedocs.io/en/latest/)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
+NumPy
 matplotlib
-scipy
-sympy
+SciPy
+SymPy
 numdifftools


### PR DESCRIPTION
**gh: #51** -  Corrected the casing of NumPy, SciPy, and SymPy wherever required. 
The changes have been made in the following files - 
- README.md
- CONTRIBUTING.md
- reqirements.txt