### PR TITLE
ci: update checkout to v4 and setup-python to v5

### DIFF
--- a/.github/workflows/pipaudit.yml
+++ b/.github/workflows/pipaudit.yml
@@ -6,7 +6,7 @@ jobs:
   selftest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install
         run: python -m pip install .
       - uses: pypa/gh-action-pip-audit@v1.0.8

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Updates the CI workflow to use current GitHub-maintained action/runtime versions.

Changes:
- `actions/checkout@v3` -> `actions/checkout@v4`
- `actions/setup-python@v3` -> `actions/setup-python@v5`

Validation:
- YAML syntax verified valid
- Diff is `.github/workflows/` only

Scope: `.github/workflows/pipaudit.yml`, `.github/workflows/pytest.yml` only.